### PR TITLE
add slack notif on pr to main

### DIFF
--- a/.github/workflows/slack-pr-notifications.yml
+++ b/.github/workflows/slack-pr-notifications.yml
@@ -3,6 +3,7 @@ name: Slack PR Notifications
 on:
   pull_request:
     types: [opened, closed]
+    branches: [main]
 
 jobs:
   notify-slack:


### PR DESCRIPTION
adding slack pr notifications to our private channel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions workflow that posts structured Slack messages when PRs are opened, merged, or closed on the main branch.
> 
> - **CI/CD**:
>   - **Workflow**: Adds `/.github/workflows/slack-pr-notifications.yml` triggered on `pull_request` (opened/closed) to `main` (non-draft only).
>   - **Payloads**: Constructs validated Slack payloads (via `jq`) for `opened`, `merged`, and `closed` with `author`, `title`, `url`, refs (`base`/`head`), and change stats; `merged` includes `merged_by` and merge commit URL.
>   - **Notification**: Sends messages via `slackapi/slack-github-action@v1.27.0` using `SLACK_WEBHOOK_URL` secret.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1cd3238d422faa9bc24552b150d5f955bd7909e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->